### PR TITLE
Fix: query using category name to category id

### DIFF
--- a/src/reservation-events/eventDTO/findStore.dto.ts
+++ b/src/reservation-events/eventDTO/findStore.dto.ts
@@ -1,5 +1,5 @@
 export class findStoreDTO {
-  categories: string[];
+  categories: number[];
 
   numberOfPeople: number;
 

--- a/src/store/store.service.ts
+++ b/src/store/store.service.ts
@@ -38,7 +38,7 @@ export class StoreService {
   async findCandidateStores(
     longitude: number,
     latitude: number,
-    categories: string[],
+    categories: number[],
     distance: number,
   ): Promise<Store[]> {
     const totalStores = [];
@@ -47,7 +47,7 @@ export class StoreService {
         relations: ['categories'],
         where: {
           categories: {
-            name: categories[i],
+            id: categories[i],
           },
         },
       });


### PR DESCRIPTION
카테고리 이름으로 날리는 쿼리를 id를 사용하여
날리는 것으로 수정